### PR TITLE
Prevent external contributors from triggering workflows via PR comments

### DIFF
--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -22,7 +22,7 @@ jobs:
           echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
 
   get-example-list:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/test-examples' ) }}
     runs-on: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
             -f context="Uptest-${{ steps.get-example-list-name.outputs.example-hash }}"
 
   uptest:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/test-examples' ) }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of your changes

This PR prevents external contributors from triggering workflows via PR comments.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
