### PR TITLE
Fix: switch back to TF_ prefixes for opentofu env vars

### DIFF
--- a/cluster/images/provider-opentofu/Dockerfile
+++ b/cluster/images/provider-opentofu/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 
 ENV OPENTOFU_VERSION=1.9.0
 ENV TF_IN_AUTOMATION=1
-ENV TOFU_PLUGIN_CACHE_DIR=/tofu/plugin-cache
+ENV TF_PLUGIN_CACHE_DIR=/tofu/plugin-cache
 
 ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/crossplane-opentofu-provider
 ADD .gitconfig .gitconfig
@@ -14,7 +14,7 @@ RUN curl -s -L https://github.com/opentofu/opentofu/releases/download/v${OPENTOF
   && unzip -d /usr/local/bin tofu.zip \
   && rm tofu.zip \
   && chmod +x /usr/local/bin/tofu \
-  && mkdir -p ${TOFU_PLUGIN_CACHE_DIR} \
+  && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
   && chown -R 2000 /tofu
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32

--- a/internal/opentofu/opentofu.go
+++ b/internal/opentofu/opentofu.go
@@ -177,14 +177,14 @@ func (h Harness) Init(ctx context.Context, o ...InitOption) error {
 	cmd := exec.Command(h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 	for _, e := range os.Environ() {
-		if strings.Contains(e, "TOFU_PLUGIN_CACHE_DIR") {
+		if strings.Contains(e, "TF_PLUGIN_CACHE_DIR") {
 			if !h.UsePluginCache {
 				continue
 			}
 		}
 		cmd.Env = append(cmd.Env, e)
 	}
-	cmd.Env = append(cmd.Env, "TOFU_CLI_CONFIG_FILE=./.tofurc")
+	cmd.Env = append(cmd.Env, "TF_CLI_CONFIG_FILE=./.tofurc")
 	if len(h.Envs) > 0 {
 		cmd.Env = append(cmd.Env, h.Envs...)
 	}


### PR DESCRIPTION
### Description of your changes

As mentioned in #14, opentofu uses the same `TF_` prefix for environment variables as terraform.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open OpenTofu Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #14

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I have verified that switching to TF_CLI_CONFIG_FILE fixes the issue. I built and pushed to a private repo a fixed provider version, and after switching to that version, the issue was fixed.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
