### PR TITLE
Fix: provide environment variables when running `tofu workspace new`

### DIFF
--- a/internal/opentofu/opentofu.go
+++ b/internal/opentofu/opentofu.go
@@ -254,6 +254,9 @@ func (h Harness) Workspace(ctx context.Context, name string) error {
 	// is somewhat optimistic, but it shouldn't hurt to try.
 	cmd = exec.Command(h.Path, "workspace", "new", "-no-color", name) //nolint:gosec
 	cmd.Dir = h.Dir
+	if len(h.Envs) > 0 {
+		cmd.Env = append(os.Environ(), h.Envs...)
+	}
 
 	if h.UsePluginCache {
 		rwmutex.RLock()


### PR DESCRIPTION
### Description of your changes

Adding the environment variables as used earlier in the function and elsewhere in the file.

Without this, envronment variables set on the workspace are passed to the `workspace select` command, but not the `workspace new` command. This causes an error when using environment variables to configure the workspace's backend.

In my specific use-case I am setting `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` to have the Google Terraform provider switch to a service account via workload identity.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open OpenTofu Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I built and pushed to a private repo a version with this fix, and the GCP authentication errors I was having went away.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
