### PR TITLE
[release-0.2] Update go version to 1.23.8 [Security]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: "1.23.7"
+  GO_VERSION: "1.23.8"
 
 jobs:
   detect-noop:

--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -9,7 +9,7 @@ on:
     types: [created]
 
 env:
-  GO_VERSION: "1.23.7"
+  GO_VERSION: "1.23.8"
 
 jobs:
   check-permissions:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/provider-opentofu
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR updates go version to fix the following:
```
NAME              INSTALLED  FIXED-IN   TYPE       VULNERABILITY        SEVERITY
stdlib            go1.23.7   1.23.8     go-module  CVE-2025-22871       Unknown
```

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

https://github.com/upbound/provider-opentofu/actions/runs/14494002157

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
