### PR TITLE
Update OPENTOFU_VERSION to 1.10.0 in Dockerfile

### DIFF
--- a/cluster/images/provider-opentofu/Dockerfile
+++ b/cluster/images/provider-opentofu/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
-ENV OPENTOFU_VERSION=1.9.0
+ENV OPENTOFU_VERSION=1.10.0
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tofu/plugin-cache
 


### PR DESCRIPTION
### Description of your changes

Bumps the opentofu container version to [1.10.0](https://github.com/opentofu/opentofu/releases/tag/v1.10.0) 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

successfully ran `make` to build multi arch images 