### PR TITLE
add basic plumbing for provider startup checks

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -36,9 +37,17 @@ import (
 
 	"github.com/upbound/provider-opentofu/apis"
 	"github.com/upbound/provider-opentofu/apis/v1beta1"
+	"github.com/upbound/provider-opentofu/internal/bootcheck"
 	workspace "github.com/upbound/provider-opentofu/internal/controller"
 	"github.com/upbound/provider-opentofu/internal/controller/features"
 )
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
+	}
+}
 
 func main() {
 	var (

--- a/internal/bootcheck/default.go
+++ b/internal/bootcheck/default.go
@@ -1,0 +1,10 @@
+//go:build !custombootcheck
+// +build !custombootcheck
+
+package bootcheck
+
+func CheckEnv() error {
+	// No-op by default. Use build tags for build-time isolation of custom preflight checks.
+	// Ensure to update the build tags on L1-L2 so that they are mutually exclusive across implementations.
+	return nil
+}


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open OpenTofu Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a simple approach to enable custom startup checks on the provider. As a concrete example, users may run their workloads in highly regulated environments where the provider should not start if the environment is not properly configured.

This implements the default path, which is a no-op. It uses a combination of an init() hook and [go build tags](https://pkg.go.dev/go/build#hdr-Build_Constraints) to:

- minimize code branching (build-time isolation)
- ensure critical checks run before anything else (fail fast)
- not require access to additional flags, env, or setup

Users can implement an array of preflight checks as separate files in this repository or a fork, and supply GO_TAGS=<..> to build an image with a specific one.

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
`make build` and install the xpkg successfully.
