### PR TITLE
Updates OpenTofu to 1.10.8 and Alpine to 3.22.2

### DIFF
--- a/cluster/images/provider-opentofu/Dockerfile
+++ b/cluster/images/provider-opentofu/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
-ENV OPENTOFU_VERSION=1.10.7
+ENV OPENTOFU_VERSION=1.10.8
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tofu/plugin-cache
 


### PR DESCRIPTION
### Description of your changes

Updates the OpenTofu runtime to 1.10.7 and the base Alpine image to 3.22.2 to pick up downstream fixes, improvements, and any security patches provided in the newer releases.

Keeps environment and plugin-cache settings intact while ensuring the image uses more up-to-date dependencies.

I have:

- [ x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Ran make and made sure it passed, also run Trivy to make sure the new Alpine image (super minor --> 3.22.1 to 3.22.2) resolves many security issues in original images
