### PR TITLE
fix(security): remediate CVE vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/provider-opentofu
 
-go 1.24.10
+go 1.24.13
 
 tool golang.org/x/tools/cmd/goimports
 


### PR DESCRIPTION
- Update Go version to 1.24.13 (fixes CVE-2025-68121, CVE-2025-61726, CVE-2025-61729, CVE-2025-61731, CVE-2025-61732, CVE-2025-61728, CVE-2025-61727, CVE-2025-61730)


(cherry picked from commit 58ee19d9b21c02fa4e045f3d9f3d203feeb3688b)

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open OpenTofu Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Please see: https://github.com/upbound/provider-opentofu/pull/128

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
